### PR TITLE
Refactoring Page modelu a controlleru. Odstraněn 'hoisting' proměnné Model.

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,13 +7,10 @@ var express = require('express')
 config.configure(app);
 config.connect(app);
 
-//controllery 
+//controllery (inicializace modelu je v controllerech)
 var PageController = require('./app/controllers/PageController');
 
-//modely
-var Page = require('./app/models/Page');
-
 //API stranky
-app.resource('pages', PageController, {base: '/api/', load: Page.findOneByUrl});
+app.resource('pages', PageController, {base: '/api/'});
    
 module.exports = app;

--- a/app/controllers/PageController.js
+++ b/app/controllers/PageController.js
@@ -4,6 +4,13 @@ var Page = require(process.cwd() + '/app/models/Page')
 filters.url = require(process.cwd() + '/lib/filters/url');
 
 /**
+ * Set the auto-load `fn`.
+ */
+exports.load = function(req, url, cb) {
+    Page.findOneByUrl(url, cb);
+}
+
+/**
  * GET /pages
  */
 exports.index = function(req, res, next){

--- a/app/models/Page.js
+++ b/app/models/Page.js
@@ -1,4 +1,5 @@
-var mongoose = require('mongoose');
+var mongoose = require('mongoose'),
+    Schema = mongoose.Schema;
 
 var fields = {
     title: {type: String, required: true}
@@ -6,13 +7,13 @@ var fields = {
   , content: {type: String, required: true}
 };
 
-var Schema = new mongoose.Schema(fields);
+var PageSchema = new Schema(fields);
 
-Schema.statics.findOneByUrl = function(url, cb) {
-    Model.findOne({url: url}, cb);
+PageSchema.statics.findOneByUrl = function(url, cb) {
+    this.findOne({url: url}, cb);
 };
 
-Schema.statics.inSchema = function(obj) {
+PageSchema.statics.inSchema = function(obj) {
     for (var field in obj) {
         if (typeof fields[field] === 'undefined') {
             return false;
@@ -21,5 +22,5 @@ Schema.statics.inSchema = function(obj) {
     return true;
 };
 
-var Model = module.exports = mongoose.model('Page', Schema);
+module.exports = mongoose.model('Page', PageSchema);
 


### PR DESCRIPTION
Nelíbil se mi zápis:

``` javascript
var Model = module.exports = mongoose.model('Page', Schema);
```

jen kvůli tomu, abych mohl použít Model o pár řádků výše ve funkci findOneByUrl (IMHO bad practice)

``` javascript
Schema.statics.findOneByUrl = function(url, cb) {
    Model.findOne({url: url}, cb);
```

Když jsem koukal do dokumentace Mongoose, tak tam používají:

``` javascript
animalSchema.statics.findByName = function (name, cb) {
  this.find({ name: new RegExp(name, 'i') }, cb);
}
```

Chvíli mi trvalo než jsem přišel na to, proč to v tomto případě nefunguje. Upravil jsem tedy definici z app.js:

``` javascript
app.resource('pages', PageController, {base: '/api/', load: Page.findOneByUrl});
```

Funkce load se v express-resource volá přímo a proto má Page.findOneByUrl globální kontext. Load jsem tedy dal přímo do PageControlleru (kam si myslím, že i patří).

Chápu, že pro účely článku to bylo takhle jednodušší na vysvětlení. Ale tohle je dle mého čistčí řešení :-) Co myslíte?
